### PR TITLE
Add Helm chart

### DIFF
--- a/helm/recommendations/.helmignore
+++ b/helm/recommendations/.helmignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/helm/recommendations/Chart.yaml
+++ b/helm/recommendations/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart to deploy recommendations on any environment
+name: recommendations
+version: 0.1.0

--- a/helm/recommendations/templates/NOTES.txt
+++ b/helm/recommendations/templates/NOTES.txt
@@ -1,0 +1,4 @@
+1. Get the application URL by running these commands:
+export FIRST_NODE_ADDRESS=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalDNS").address')
+export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "recommendations.fullname" . }})
+echo http://$FIRST_NODE_ADDRESS:$NODE_PORT

--- a/helm/recommendations/templates/_helpers.tpl
+++ b/helm/recommendations/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "recommendations.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "recommendations.fullname" -}}
+{{- default .Release.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "recommendations.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/recommendations/templates/app-configmap.yaml
+++ b/helm/recommendations/templates/app-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-configmap
+data:
+  config.php: |
+    <?php
+    
+    return [
+        'api.uri' => '{{ .Values.apiUrl }}',
+    ];

--- a/helm/recommendations/templates/deployment.yaml
+++ b/helm/recommendations/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "recommendations.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "recommendations.name" . }}
+    helm.sh/chart: {{ include "recommendations.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: {{ include "recommendations.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "recommendations.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "recommendations.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: app
+        app.kubernetes.io/part-of: {{ include "recommendations.name" . }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: app-config-volume
+              mountPath: /srv/recommendations/config.php
+              subPath: config.php
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+        - name: web
+          image: nginx:1.13.12-alpine
+          volumeMounts:
+            - name: nginx-config-volume
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+          ports:
+            - containerPort: 80
+              protocol: TCP
+      # TODO: same for config.php
+      volumes:
+        - name: app-config-volume
+          configMap:
+            name: app-configmap
+            items:
+            - key: config.php
+              path: config.php
+        - name: nginx-config-volume
+          configMap:
+            name: nginx-configmap
+            items:
+            - key: default.conf
+              path: default.conf

--- a/helm/recommendations/templates/nginx-configmap.yaml
+++ b/helm/recommendations/templates/nginx-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configmap
+data:
+  default.conf: |
+    server {
+        listen 80;
+        root /srv/recommendations/web;
+    
+        location / {
+            try_files $uri /app.php$is_args$args;
+        }
+    
+        location ~ ^/app\.php(/|$) {
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $request_filename;
+            fastcgi_intercept_errors on;
+            fastcgi_pass localhost:9000;
+            internal;
+        }
+    
+        # return 404 for all other php files not matching the front controller
+        # this prevents access to other php files you don't want to be accessible.
+        location ~ \.php$ {
+            return 404;
+        }
+
+        access_log stderr;
+        error_log stderr;
+    }

--- a/helm/recommendations/templates/service.yaml
+++ b/helm/recommendations/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "recommendations.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "recommendations.name" . }}
+    helm.sh/chart: {{ include "recommendations.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    app.kubernetes.io/part-of: {{ include "recommendations.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "recommendations.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/recommendations/values.yaml
+++ b/helm/recommendations/values.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: elifesciences/recommendations
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+apiUrl: https://api.elifesciences.org


### PR DESCRIPTION
Part of https://github.com/elifesciences/issues/issues/4806 but unsure on how many environments could be used yet.

Deployed with:
```
helm upgrade recommendations--staging ./recommendations --install --wait --set image.tag=ae5325f1d39ba0eb8f24b7084206e79cf76a5550
export FIRST_NODE_ADDRESS=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalDNS").address')
export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services recommendations--staging)
curl -v $FIRST_NODE_ADDRESS:$NODE_PORT/recommendations/article/10627
```

Lacks New Relic and Loggly integration so not suitable for `prod` (and hence `end2end`) yet.