### PR TITLE
Deploy through container image

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -1,9 +1,6 @@
 base:
     '*':
         - elife
-        - elife.php7
-        - elife.composer
         - elife.nginx
-        - elife.nginx-php7
+        - elife.docker
         - recommendations
-        - elife.proofreader-php

--- a/salt/pillar/recommendations.sls
+++ b/salt/pillar/recommendations.sls
@@ -1,7 +1,3 @@
 recommendations:
     api:
         uri: https://api.elifesciences.org/
-
-elife:
-    proofreader_php:
-        version: 0.2

--- a/salt/recommendations/config/etc-nginx-sites-enabled-recommendations.conf
+++ b/salt/recommendations/config/etc-nginx-sites-enabled-recommendations.conf
@@ -19,11 +19,9 @@ server {
     location ~ ^/app_{{ pillar.elife.env }}\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $request_filename;
-        fastcgi_param DOCUMENT_ROOT $realpath_root;
-        fastcgi_param ENVIRONMENT_NAME {{ pillar.elife.env }};
         fastcgi_intercept_errors on;
-        fastcgi_pass unix:/var/php-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_pass localhost:9000;
         internal;
     }
 

--- a/salt/recommendations/config/etc-nginx-sites-enabled-recommendations.conf
+++ b/salt/recommendations/config/etc-nginx-sites-enabled-recommendations.conf
@@ -13,10 +13,10 @@ server {
     }
 
     location / {
-        try_files $uri /app_{{ pillar.elife.env }}.php$is_args$args;
+        try_files $uri /app.php$is_args$args;
     }
 
-    location ~ ^/app_{{ pillar.elife.env }}\.php(/|$) {
+    location ~ ^/app\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         include fastcgi_params;
         fastcgi_intercept_errors on;
@@ -25,7 +25,7 @@ server {
         internal;
     }
 
-    location ~ /app_.*.php$ {
+    location ~ /app\.php$ {
         return 404;
     }
 

--- a/salt/recommendations/config/srv-recommendations-.env
+++ b/salt/recommendations/config/srv-recommendations-.env
@@ -1,0 +1,2 @@
+COMPOSE_PROJECT_NAME=recommendations
+IMAGE_TAG={{ salt['elife.image_tag']() }}

--- a/salt/recommendations/config/srv-recommendations-containers.env
+++ b/salt/recommendations/config/srv-recommendations-containers.env
@@ -1,4 +1,9 @@
-APP_ENV={{ pillar.elife.env }}
+{%- if pillar.elife.env == 'dev' -%}
+{%- set app_env = 'ci' -%}
+{%- else -%}
+{%- set app_env = pillar.elife.env -%}
+{%- endif -%}
+APP_ENV={{ app_env }}
 NEW_RELIC_ENABLED={{ pillar.elife.newrelic.enabled }}
 NEW_RELIC_APP_NAME={{ salt['elife.cfg']('project.stackname') }}
 NEW_RELIC_LICENSE_KEY={{ pillar.elife.newrelic.license }}

--- a/salt/recommendations/config/srv-recommendations-containers.env
+++ b/salt/recommendations/config/srv-recommendations-containers.env
@@ -1,0 +1,4 @@
+APP_ENV={{ pillar.elife.env }}
+NEW_RELIC_ENABLED={{ pillar.elife.newrelic.enabled }}
+NEW_RELIC_APP_NAME={{ salt['elife.cfg']('project.stackname') }}
+NEW_RELIC_LICENSE_KEY={{ pillar.elife.newrelic.license }}

--- a/salt/recommendations/config/srv-recommendations-docker-compose.yml
+++ b/salt/recommendations/config/srv-recommendations-docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+    fpm:
+        image: "elifesciences/recommendations:${IMAGE_TAG}"
+        volumes:
+            - ./config.php:/srv/recommendations/config.php
+            - ./var:/srv/recommendations/var
+        ports:
+            - "9000:9000"
+        env_file:
+            - ./containers.env
+        restart: always

--- a/salt/recommendations/config/srv-recommendations-smoke_tests.sh
+++ b/salt/recommendations/config/srv-recommendations-smoke_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+[ $(curl --write-out %{http_code} --silent --output /dev/null localhost/ping) == 200 ]

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -7,6 +7,12 @@ recommendations-folder:
             - user
             - group
 
+recommendations-folder-old-git-repository:
+    file.absent:
+        - name: /srv/recommendations/.git
+        - require:
+            - recommendations-folder
+
 recommendations-var-folder:
     file.directory:
         - name: /srv/recommendations/var

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -72,10 +72,12 @@ recommendations-docker-compose-containers-env:
             - recommendations-folder
 
 # deprecated, remove when no longer necessary
-# if not stopped, may conflict with port 9000 forwarded from the host to the container
 stop-existing-php-fpm:
     cmd.run:
         - name: stop php7.0-fpm || true
+        # if not stopped, may conflict with port 9000 forwarded from the host to the container
+        - require_in:
+            - cmd: recommendations-docker-compose
 
 recommendations-docker-compose:
     file.managed:

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -126,4 +126,4 @@ recommendations-smoke-tests:
         - name: /srv/recommendations/smoke_tests.sh
         - mode: 755
         - require:
-            - recommendations-nginx-vhost
+            - recommendations-folder

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -71,6 +71,12 @@ recommendations-docker-compose-containers-env:
         - require:
             - recommendations-folder
 
+# deprecated, remove when no longer necessary
+# if not stopped, may conflict with port 9000 forwarded from the host to the container
+stop-existing-php-fpm:
+    cmd.run:
+        - name: stop php7.0-fpm || true
+
 recommendations-docker-compose:
     file.managed:
         - name: /srv/recommendations/docker-compose.yml

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -124,5 +124,6 @@ recommendations-smoke-tests:
     file.managed:
         - source: salt://recommendations/config/srv-recommendations-smoke_tests.sh
         - name: /srv/recommendations/smoke_tests.sh
+        - mode: 755
         - require:
             - recommendations-nginx-vhost

--- a/salt/recommendations/init.sls
+++ b/salt/recommendations/init.sls
@@ -113,3 +113,10 @@ logrotate-recommendations-logs:
         - template: jinja
         - require:
             - recommendations-logs
+
+recommendations-smoke-tests:
+    file.managed:
+        - source: salt://recommendations/config/srv-recommendations-smoke_tests.sh
+        - name: /srv/recommendations/smoke_tests.sh
+        - require:
+            - recommendations-nginx-vhost


### PR DESCRIPTION
Switches the `recommendations` servers from using a checkout of the PHP source code to using a Docker container running `php-fpm`. As a result PHP is not installed anymore on the servers.